### PR TITLE
Simple fix to allow connecting to a remote Redis.

### DIFF
--- a/websauna/system/core/redis.py
+++ b/websauna/system/core/redis.py
@@ -50,6 +50,8 @@ def get_redis(registry:Registry=None, url:str=None, redis_client=StrictRedis, **
     if redis is not None:
         return redis
 
+    # if no url passed, try to get it from pyramid settings
+    url = registry.settings.get('redis.sessions.url') if url is None else url
     # otherwise create a new connection
     if url is not None:
         # remove defaults to avoid duplicating settings in the `url`


### PR DESCRIPTION
The current implementation of get_redis does not get redis.session.url from .ini file and aways tries to connect to localhost Redis.
I believe it is not the ideal solution for this but since I can see there are still some work to be done in this function this fix would allow connect to a remote redis until core developers get back to work on it.