### PR TITLE
[WIP] Add cookiecutter scaffold project generation support.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -18,4 +18,5 @@ omit =
     websauna/utils/orderedset.py
     websauna/tests/*
     websauna/system/http/*
+    websauna/scaffolds/cookiecutter/*
 

--- a/docs/source/narrative/misc/addons.rst
+++ b/docs/source/narrative/misc/addons.rst
@@ -24,7 +24,7 @@ Addons vs. applications
 Creating addon
 --------------
 
-* Use ``pcreate`` command with ``websauna_addon`` scaffold.
+* Use ``ws-create`` command with ``websauna_addon`` scaffold.
 
 * Install addon to your virtualenv after creation: ``pip install -e .["test"]``
 

--- a/docs/source/narrative/misc/scaffolds.rst
+++ b/docs/source/narrative/misc/scaffolds.rst
@@ -4,7 +4,7 @@
 Scaffolds
 =========
 
-There are two different starting points for new Websauna projects. Both are available through :term:`pcreate` command.
+There are two different starting points for new Websauna projects. Both are available through :term:`ws-create` command.
 
 websauna_app
 ------------

--- a/docs/source/reference/glossary.rst
+++ b/docs/source/reference/glossary.rst
@@ -50,6 +50,9 @@ Many glossary descrpitions are taken from `Wikipedia <https://en.wikipedia.org/>
     Colander
         A simple schema-based serialization and deserialization library. Useful for building forms, RESTFul APIs and other interfaces where you need to transform and validate data. `More information <https://pypi.python.org/pypi/colander>`__.
 
+    Cookiecutter
+      Cookiecutter creates projects from project templates, e.g. Python package projects. `More info <https://cookiecutter.readthedocs.io>`__.
+
     colanderalchemy
         A Python package to generate :term:`Colander` forms from :term:`SQLAlchemy` models. `More information <https://pypi.python.org/pypi/ColanderAlchemy>`__.
 
@@ -149,9 +152,6 @@ Many glossary descrpitions are taken from `Wikipedia <https://en.wikipedia.org/>
 
     Paste
       A Python framework for building web applications on the top of `WSGI protocol <https://en.wikipedia.org/wiki/Web_Server_Gateway_Interface>`__. See `Paste documentation <https://pypi.python.org/pypi/Paste>`__ .
-
-    pcreate
-      A command line command for creating new packages based on :term:`Pyramid` framework. `More info <http://docs.pylonsproject.org/projects/pyramid/en/1.3-branch/narr/project.html>`__.
 
     persistent
         Something written on a disk e.g. it doesn't disappear when power goes down or the computer is restarted.

--- a/docs/source/tutorials/gettingstarted/tutorial_03.rst
+++ b/docs/source/tutorials/gettingstarted/tutorial_03.rst
@@ -12,11 +12,15 @@ Enter to your project folder and make sure the :term:`virtual environment` is ac
     cd myproject
     source venv/bin/activate
 
-Websauna uses :term:`Pyramid`'s :term:`pcreate` command and a scaffold mechanism to bootstrap a new project. The `pcreate` command is installed in `venv/bin` folder. To create your application, type::
+Websauna uses :term:`Cookiecutter`'s scaffold mechanism to bootstrap a new project. The `ws-create` command is installed in `venv/bin` folder. To create your application, type::
 
-    pcreate -t websauna_app myapp  # Replace myapp with a creative all lowercase alphanumeric name
+    ws-create -h
 
-This will create a project structure similar to::
+This will show you all the posible options for this command. If you type::
+
+    ws-create --app websauna_app
+
+This will create a project structure similar to (assuming you named your project 'myapp')::
 
     myapp/                          # Python package root
     myapp/myapp                     # Python module "myapp" with all .py files

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,10 @@ setup(
 
         # Misc
         "scandir",  # os.scandir backport for py3.4
-        "python-slugify", # ASCII slug generation
+        "python-slugify",  # ASCII slug generation
+
+        # Project scaffolding
+        "cookiecutter>=1.4",
     ],
 
     # List additional groups of  dependencies here (e.g. development
@@ -130,7 +133,7 @@ setup(
             'sphinx-autodoc-typehints',
             'sphinx_rtd_theme',
             'sphinxcontrib-zopeext',
-            'zest.releaser'
+            'zest.releaser',
         ],
 
         'test': [
@@ -178,6 +181,7 @@ setup(
             'ws-create-table=websauna.system.devop.scripts.createtable:main',
             'ws-sanity-check=websauna.system.devop.scripts.sanitycheck:main',
             'ws-collect-static=websauna.system.devop.scripts.collectstatic:main',
+            'ws-create=websauna.system.devop.scripts.cookiecutter:main',
         ],
 
         'paste.app_factory': [

--- a/websauna/system/core/interfaces.py
+++ b/websauna/system/core/interfaces.py
@@ -67,7 +67,7 @@ class IContainer(ILocation):
     TODO: Not sure if items() is the best way to do the child discovery. All ideas accepted.
     """
 
-    def items() -> Iterable[Tuple[str, ILocation]]:
+    def items() -> Iterable[Tuple]:
         """Return children in this container as (id, Resource instance) tuples.
 
         This usually dynamically populates from the database when this is called and there is no caching. The result is iterable only once.

--- a/websauna/system/devop/scripts/cookiecutter.py
+++ b/websauna/system/devop/scripts/cookiecutter.py
@@ -1,0 +1,46 @@
+"""ws-create script."""
+
+import argparse
+import os
+import binascii
+from cookiecutter.main import cookiecutter
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Websauna project generator.')
+    parser.add_argument(
+        '--app',
+        dest='scaffold',
+        default='websauna_app',
+        help='Project scaffold to use for this project (default: websauna_app)',
+    )
+    parser.add_argument(
+        '--no-input',
+        dest='no_input',
+        default=False,
+    )
+    args = parser.parse_args()
+
+    print("Starting to generate new project with cookiecutter ...")
+
+    authentication_random = binascii.hexlify(os.urandom(20)).decode("utf-8")
+    authomatic_random = binascii.hexlify(os.urandom(20)).decode("utf-8")
+    session_random = binascii.hexlify(os.urandom(20)).decode("utf-8")
+
+    scaffolds = {
+        'websauna_app': 'https://github.com/karantan/websauna-cookiecutter',
+        'websauna_addon': 'https://github.com/karantan/websauna-cookiecutter-addon',
+    }
+
+    if scaffolds.get(args.scaffold):
+        cookiecutter(
+            scaffolds[args.scaffold],
+            no_input=args.no_input,
+            extra_context={
+                'authentication_random': authentication_random,
+                'authomatic_random': authomatic_random,
+                'session_random': session_random,
+            },
+        )
+    else:
+        print("[*] Scaffold {} not found.".format(args.scaffold))

--- a/websauna/tests/create_wheelhouse.bash
+++ b/websauna/tests/create_wheelhouse.bash
@@ -28,7 +28,7 @@ pip install -q -U pip
 
 # We do the messages three phases as otherwise Travis considers our build stalled after 10m and I hope this solves this
 echo "Installing project core dependencies."
-pip install -q .
+pip install -q -e .
 echo "Installing project test dependencies."
 pip install -q ".[test]"
 echo "Installing project dev dependencies."

--- a/websauna/tests/scaffold.py
+++ b/websauna/tests/scaffold.py
@@ -1,15 +1,16 @@
 """Scaffold test utility functions."""
+import binascii
 import sys
 import subprocess
 import time
 from contextlib import closing, contextmanager
 import os
-from shutil import which
 from tempfile import mkdtemp
 
 import psycopg2
 import pytest
 
+from cookiecutter.main import cookiecutter
 from websauna.compat.typing import List
 
 
@@ -218,7 +219,21 @@ def app_scaffold(request) -> str:
     execute_venv_command("cd {} ; pip install -e .[notebook,utils]".format(websauna_folder), folder, timeout=5*60)
 
     # Create scaffold
-    execute_venv_command("pcreate --ignore-conflicting-name -s websauna_app myapp", folder)
+    authentication_random = binascii.hexlify(os.urandom(20)).decode("utf-8")
+    authomatic_random = binascii.hexlify(os.urandom(20)).decode("utf-8")
+    session_random = binascii.hexlify(os.urandom(20)).decode("utf-8")
+    cookiecutter(
+        'https://github.com/karantan/websauna-cookiecutter',
+        no_input=True,
+        extra_context={
+            'authentication_random': authentication_random,
+            'authomatic_random': authomatic_random,
+            'session_random': session_random,
+            'project_name': 'myapp',
+            'db_name': 'myapp',
+        },
+        output_dir=folder,
+    )
 
     # Instal package created by scaffold
     content_folder = os.path.join(folder, "myapp")

--- a/websauna/tests/test_scaffold_addon.py
+++ b/websauna/tests/test_scaffold_addon.py
@@ -5,10 +5,12 @@ Rerunning these tests can be greatly sped up by creating a local Python package 
     bash websauna/tests/create_wheelhouse.bash
 
 """
+import binascii
 import time
 
 import os
 import pytest
+from cookiecutter.main import cookiecutter
 from flaky import flaky
 
 from .scaffold import execute_venv_command, insert_content_after_line
@@ -45,9 +47,22 @@ def addon_scaffold(request, app_scaffold):
 
     folder = app_scaffold
 
-    execute_venv_command("pcreate -s websauna_addon myaddon", folder)
-
-    content_folder = os.path.join(folder, "websauna.myaddon")
+    # Create scaffold
+    authentication_random = binascii.hexlify(os.urandom(20)).decode("utf-8")
+    authomatic_random = binascii.hexlify(os.urandom(20)).decode("utf-8")
+    session_random = binascii.hexlify(os.urandom(20)).decode("utf-8")
+    cookiecutter(
+        'https://github.com/karantan/websauna-cookiecutter-addon',
+        no_input=True,
+        extra_context={
+            'authentication_random': authentication_random,
+            'authomatic_random': authomatic_random,
+            'session_random': session_random,
+            'project_name': 'myaddon',
+            'db_name': 'myaddon',
+        },
+        output_dir=folder,
+    )
 
     # Instal package created by scaffold
     execute_venv_command("cd websauna.myaddon && pip install -e .", folder, timeout=5 * 60)


### PR DESCRIPTION
Usage:
```
> ws-create -h
usage: ws-create [-h] [--app SCAFFOLD]

Websauna project generator.

optional arguments:
  -h, --help      show this help message and exit
  --app SCAFFOLD  Project scaffold to use for this project (default: websauna_app)

```

This cookiecutter is using fetching cookiecutter from this repo: https://github.com/karantan/websauna-cookiecutter

Idea is to make create a system that will allow any user to add his own cookietemplate into websauna `ws-create` tool.

NOTE: WIP is added because I need to fix the documentation and figure it out why travis is not getting cookiecutter.