### PR TITLE
Made wesaunas pytest plugins externally available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -191,6 +191,10 @@ setup(
         'pyramid.scaffold': [
             "websauna_app=websauna.scaffolds:App",
             "websauna_addon=websauna.scaffolds:Addon",
-        ]
+        ],
+
+        'pytest11': [
+            'websauna = websauna.tests.fixtures',
+        ],
     },
 )


### PR DESCRIPTION
After trying running tests on newly created websauna application I discovered that none of websaunas pytest fixtures are available, including the `--ini` option:

   > bin/py.test src/enkiblog/enkiblog/tests/functional/test_models.py --ini var/conf/instance.ini 
   usage: py.test [options] [file_or_dir] [file_or_dir] [...]
   py.test: error: unrecognized arguments: --ini var/conf/instance.ini
      inifile: None
      rootdir: /home/enkidulan/projects/websauna.enkiblog

The issue was that wesauna pytest plugins was not externally available, so to fix it I added websauna pytest fixtures as the package entry_points as [pytest docs says](http://doc.pytest.org/en/latest/writing_plugins.html#making-your-plugin-installable-by-others).