### PR TITLE
Add missing argument for authenticate_user

### DIFF
--- a/websauna/system/user/loginservice.py
+++ b/websauna/system/user/loginservice.py
@@ -155,7 +155,7 @@ class DefaultLoginService:
 
         user = self.check_credentials(username, password)
 
-        return self.authenticate_user(user, login_source)
+        return self.authenticate_user(user, login_source, location)
 
     def logout(self, location=None) -> Response:
         """Log out user from the site.


### PR DESCRIPTION
`authenticate_credentials` calls `authenticate_user` without the location parameter causing redirect to default to config settings