### PR TITLE
Add tests and updated docs for `simple_route`  #121

### DIFF
--- a/websauna/system/core/route.py
+++ b/websauna/system/core/route.py
@@ -13,31 +13,20 @@ class simple_route(object):
 
     Pyramid's URL dispatch has separate concepts for routes and views. This gives additional flexibility in that you can one route map to multiple views, using different predicates (e.g.: predicates depending on Accept header, whether request is XHR or not, etc.). In many applications, this flexibility is not needed and having both routes and views adds a bit of complexity and duplication, and reduces DRYness. This module implements some easy-to-use mechanisms that create a route and a view in one step, resulting in simpler, easier to understand code. This kind of makes Pyramid's routing look a bit more like Flask, albeit without Flask's controversial thread locals.
 
-    Example:
+    .. note:: At the moment ``simple_route`` doesn't support ``viewdefaults``.
 
-    .. code-block:: python
+    Examples:
 
-        from websauna.system.core.route import simple_route
+    .. literalinclude:: ../../../websauna/tests/viewconfig/simple_route_tests_views.py
 
-        @simple_route('/path/to/view', renderer='myapp/example.html')
-        def view_callable(request):
-            return {'message': 'Hello'}
+    Respectively URLs for registered views are:
 
-    You can set route name explicitly:
-
-    .. code-block:: python
-
-        from websauna.system.core.route import simple_route
-
-        @simple_route('/path/to/view/{arg}', route_name="foobar")
-        def view_callable(request):
-            arg = request.matchdict["arg"]
-            return {'message': 'Hello {}'.format(arg}
-
-        url = request.route_url("foobar", dict(arg="123"))
+    .. literalinclude:: ../../../websauna/tests/test_simple_route.py
+        :pyobject: test_registered_routes_docs
+        :dedent: 11
+        :lines: 4-
 
     """
-
     def __init__(self, path, *args, **kwargs):
         """Constructor just here to accept parameters for decorator"""
         self.path = path

--- a/websauna/tests/test_simple_route.py
+++ b/websauna/tests/test_simple_route.py
@@ -69,3 +69,15 @@ def test_method_of_a_class(testapp):
 def test_class_method_by_attr(testapp):
     res = testapp.get('/class-attr')
     assert res.body == b'class-attr'
+
+
+def test_registered_routes_docs(config):
+    config.get_routes_mapper()
+    request = testing.DummyRequest()
+    assert request.route_url('view_callable')           == 'http://example.com/path/to/view'
+    assert request.route_url('foobar', arg='123')       == 'http://example.com/path/to/view/123'
+    assert request.route_url('edit')                    == 'http://example.com/edit'
+    assert request.route_url('change')                  == 'http://example.com/change'
+    assert request.route_url('ClassAsAView')            == 'http://example.com/class-as-a-view'
+    assert request.route_url('MyViewClass.amethod')     == 'http://example.com/amethod'
+    assert request.route_url('MyViewClassAttr.amethod') == 'http://example.com/class-attr'

--- a/websauna/tests/test_simple_route.py
+++ b/websauna/tests/test_simple_route.py
@@ -1,0 +1,71 @@
+"""
+These tests aim to ensure that websauna's ``simple_route`` can be used in the
+same way as pyramid's ``view_config``. Tests are inspired by pyramid's
+`viewconfig documentation`_ and aim to check that the provided examples of the
+use of ``view_config`` are also applicable to ``simple_route``.
+
+.. _`viewconfig documentation`: https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/viewconfig.html#adding-view-configuration-using-the-view-config-decorator
+
+"""
+
+import pytest
+from pyramid import testing
+from webtest import TestApp
+
+
+@pytest.fixture(scope='module')
+def config():
+    with testing.setUp() as config:
+        config.scan('websauna.tests.viewconfig.simple_route_tests_views')
+        yield config
+
+
+@pytest.fixture(scope='module')
+def testapp(config):
+    yield TestApp(config.make_wsgi_app())
+
+
+def test_registered_routes(config):
+    expected_routes = [
+        'ClassAsAView',
+        'MyViewClass.amethod',
+        'MyViewClassAttr.amethod',
+        'edit',
+        'change',
+        'foobar',
+        'view_callable',
+    ]
+    actual_routes = [i.name for i in config.get_routes_mapper().get_routes()]
+    assert expected_routes == actual_routes
+
+
+def test_view_callable(testapp):
+    res = testapp.get('/path/to/view')
+    assert res.body == b'Hello'
+
+
+def test_route_items(testapp):
+    res = testapp.post('/path/to/view/Joe')
+    assert res.body == b'{"message": "Hello Joe"}'
+
+
+def test_class_as_a_view(testapp):
+    res = testapp.get('/class-as-a-view')
+    assert res.body == b'class-as-a-view'
+
+
+def test_muliple_simple_route_decorators(testapp):
+    res = testapp.get('/edit')
+    assert res.body == b'edited!'
+    res = testapp.get('/change')
+    assert res.body == b'edited!'
+
+
+def test_method_of_a_class(testapp):
+    res = testapp.get('/amethod')
+    assert res.body == b'amethod'
+
+
+def test_class_method_by_attr(testapp):
+    res = testapp.get('/class-attr')
+    assert res.body == b'class-attr'

--- a/websauna/tests/viewconfig/simple_route_tests_views.py
+++ b/websauna/tests/viewconfig/simple_route_tests_views.py
@@ -1,0 +1,67 @@
+from pyramid.response import Response
+from websauna.system.core.route import simple_route
+
+
+# ``simple_route`` decorator can be used to associate view configuration
+# information with a function, method, or class that acts as a Pyramid view
+# callable.
+@simple_route('/path/to/view')
+def view_callable(request):
+    return Response('Hello')
+
+
+# You can set route name or any of view configuration arguments explicitly.
+@simple_route(
+    '/path/to/view/{arg}',
+    route_name='foobar',
+    request_method='POST',
+    renderer='json')
+def my_view(request):
+    arg = request.matchdict["arg"]
+    return {'message': 'Hello {}'.format(arg)}
+
+
+# More than one decorator can be stacked on top of any number of others. Each
+# decorator creates a separate route and view registration. It's better to
+# provide ``route_name`` explicitly in this case.
+@simple_route('/change', route_name='change')
+@simple_route('/edit', route_name='edit')
+def edit(request):
+    return Response('edited!')
+
+
+# ``simple_route` can be used as a class decorator.
+@simple_route('/class-as-a-view')
+class ClassAsAView(object):
+    def __init__(self, request):
+        self.request = request
+
+    def __call__(self):
+        return Response('class-as-a-view')
+
+
+# The decorator can also be used against a method of a class.
+class MyViewClass(object):
+
+    # Class constructor must accept an argument list in one of two forms:
+    #   * either a single argument, request, or
+    #   * two arguments, context, request.
+    def __init__(self, request):
+        self.request = request
+
+    # The method which is decorated must return a response.
+    @simple_route('/amethod')
+    def amethod(self):
+        return Response('amethod')
+
+
+# Using the decorator against a particular method of a class is equivalent to
+# using the attr parameter in a decorator attached to the class itself.
+@simple_route('/class-attr', attr='amethod')
+class MyViewClassAttr(object):
+
+    def __init__(self, request):
+        self.request = request
+
+    def amethod(self):
+        return Response('class-attr')


### PR DESCRIPTION
I went through examples in [Adding View Configuration Using the `view_config` Decorator](https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/viewconfig.html#adding-view-configuration-using-the-view-config-decorator) and wrote tests that do kind-of the same with `simple_route`.

It appeared that `simple_route` doesn't work with `viewdefaults`, but besides it, the decorator works fine as a drop-in replacement for `view_config`.

I also updated examples in docs on how to use `simple_route`, previous examples contained errors and were not a part of a testing process. See the screenshot attached below. 
![screenshot-2017-12-2 websauna system core route module websauna](https://user-images.githubusercontent.com/963412/33516258-556a9a60-d7a2-11e7-9194-3a84e5e0246d.png)

