### PR TITLE
Fix view retrying for PostgreSQL serialization errors (TransactionRollbackError)

### DIFF
--- a/websauna/system/core/views/internalservererror.py
+++ b/websauna/system/core/views/internalservererror.py
@@ -58,7 +58,4 @@ def internal_server_error(context, request):
     # Hint pyramid_redis_session not to generate any session cookies for this response
     resp.cache_control.public = True
 
-    # Make sure nothing is written or no transaction left open on 500
-    request.tm.abort()
-
     return resp


### PR DESCRIPTION
Websauna should automatically retry views if a retryable exception occurs. However, this is currently bugged: Websauna won't retry views where a `psycopg2.extensions.TransactionRollbackError` is thrown (ie. when a serialization error occurs in PostgreSQL)

This can be tested manually by following instructions in this repo: https://github.com/koirikivi/websauna_retry_test

The first commit removes call to `request.tm.abort()` in `websauna.system.core.views.internalservererror.internal_server_error`. This call should not be needed, as `pyramid_tm` should handle the rollback in the case of an exception.

The second commit amends `websauna.system.core.views.internalservererror.internal_server_error` to avoid spamming `logger.exception` when a view is retried. I'm less sure about the implementation here, though it seems to work empirically. Review kindly requested!

Full story:

- Websauna uses `pyramid_retry` to handle view retrying
- `pyramid_retry` needs `request.exception` to retry
- `request.invoke_exception_view` sets `request.exception` but only if
  it returns a view. If no exception view is configured,
  `request.exception` will be `None`.
- Websauna adds a default exception view
  (websauna.system.core.views.internalservererror.internal_server_error),
  However, this is disabled in development by default since debug toolbar is
  enabled by default. In production settings, debug toolbar is disabled and
  `pyramid_retry` SHOULD work.
- However, calling `request.tm.abort()` kills the current zope transaction,
  which causes a new transaction to be created when the retry process happens.
- This new transaction no longer has the `SessionDataManager` from
  `zope.sqlalchemy` attached, which means that it no longer knows how to retry
  certain database exceptions, like those raised by psycopg2 when a
  serialization error occurs.
