### PR TITLE
Pin dependencies and fix flake8 errors to fix tests and fresh installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
         "python-slugify",  # ASCII slug generation
 
         # Redis
-        "redis>=3.2.0",
+        "redis==2.10.6",
     ],
 
     extras_require={
@@ -127,7 +127,7 @@ setup(
         # Command line utilities and like that are needed to make development / production environment friendly
         'utils': ['pgcli>=2'],
         # Using celery based async tasks
-        'celery': ['celery[redis]>=4.3.0,<5.0.0']
+        'celery': ['celery[redis]>=4.2.0,<4.3.0']  # Celery 4.3.0 wants a newer redis, which seems to break stuff
     },
 
     # To provide executable scripts, use entry points in preference to the

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,9 @@ setup(
     zip_safe=False,
     python_requires='>=3.5.2',
     install_requires=[
+        # Pinned versions. It seems that these need to be here on top
+        "psycopg2>=2.7.4,<2.8",  # pgcli wants <2.8
+
         # Pyramid dependencies
         'pyramid>=1.10',
         'transaction>=2.4.0',
@@ -87,7 +90,7 @@ setup(
         "python-slugify",  # ASCII slug generation
 
         # Redis
-        "redis==2.10.6",
+        "redis>=3.2.0",
     ],
 
     extras_require={
@@ -116,6 +119,7 @@ setup(
             'pytest-timeout',
             'pytest<4.0',
             'webtest',
+            'urllib3>=1.21.1,<1.25',  # Pinned version to avoid breaking tests
         ],
         "notebook": [
             "pyramid_notebook>=0.3.0",
@@ -123,7 +127,7 @@ setup(
         # Command line utilities and like that are needed to make development / production environment friendly
         'utils': ['pgcli>=2'],
         # Using celery based async tasks
-        'celery': ['celery[redis]>=4.2.0,<5.0.0']
+        'celery': ['celery[redis]>=4.3.0,<5.0.0']
     },
 
     # To provide executable scripts, use entry points in preference to the

--- a/websauna/system/crud/views.py
+++ b/websauna/system/crud/views.py
@@ -33,6 +33,9 @@ from . import CRUD
 from . import Resource
 from . import paginator
 
+if t.TYPE_CHECKING:
+    from .listing import Table
+
 
 class ResourceButton:
     """Present a button on the top right corner of CRUD views.
@@ -643,7 +646,7 @@ class Add(FormView):
         self.add_object(obj)
         return obj
 
-    def get_buttons(self)-> t.List[deform.form.Button]:
+    def get_buttons(self) -> t.List[deform.form.Button]:
         buttons = (
             deform.form.Button("add"),
             deform.form.Button("cancel"),

--- a/websauna/system/form/fieldmapper.py
+++ b/websauna/system/form/fieldmapper.py
@@ -167,7 +167,7 @@ class DefaultSQLAlchemyFieldMapper(ColumnToFieldMapper):
         if column.primary_key:
             # TODO: Looks like column.autoincrement is set True by default, so we cannot use it here
             # if mode in (EditMode.edit, EditMode.add):
-                # return TypeOverridesHandling.drop, {}
+            #     return TypeOverridesHandling.drop, {}
             return TypeOverridesHandling.drop, {}
 
         if column.foreign_keys:
@@ -212,7 +212,7 @@ class DefaultSQLAlchemyFieldMapper(ColumnToFieldMapper):
 
         def _map_column(node, name, column, column_type):
             # if name == 'email':
-                # import pdb; pdb.set_trace()
+            #     import pdb; pdb.set_trace()
             return self.map_column(mode, request, node, model, name, column, column_type)
 
         def _map_relationship(node: colander.SchemaNode, name: str, prop: RelationshipProperty, mapper: Mapper):

--- a/websauna/tests/cookiecutter/test_cookiecutter_websauna_app.py
+++ b/websauna/tests/cookiecutter/test_cookiecutter_websauna_app.py
@@ -70,7 +70,7 @@ def test_pserve(app_scaffold, dev_db, browser):  # noQA
 
 # On Travis there might be abnormal delays in this test
 @flaky  # noQA
-def test_pyramid_debugtoolbar(app_scaffold, dev_db, browser):
+def test_pyramid_debugtoolbar(app_scaffold, dev_db, browser):  # noQA: F811
     """Pyramid debug toolbar should be effective with the default development pserve."""
     # User models are needed to start the web server
     execute_ws_command('ws-sync-db', app_scaffold)
@@ -137,7 +137,7 @@ def test_app_sanity_check_fail(app_scaffold, dev_db):  # noQA
 
 # DB dump on Travis might hung?
 @flaky  # noQA
-def test_dump_db(app_scaffold, dev_db):
+def test_dump_db(app_scaffold, dev_db):  # noQA: F811
     """Test database dump."""
     execute_ws_command('ws-sync-db', app_scaffold)
     execute_ws_command('ws-dump-db', app_scaffold)
@@ -145,7 +145,7 @@ def test_dump_db(app_scaffold, dev_db):
 
 # Browser doesn't come up timely on Travis
 @flaky  # noQA
-def test_create_user(app_scaffold, dev_db, browser):
+def test_create_user(app_scaffold, dev_db, browser):  # noQA: F811
     """Test creating user from command line and logging in as this user."""
     execute_ws_command('ws-sync-db', app_scaffold)
     cmdline = 'ws-create-user {config} mikko@example.com secret'.format(config=CONFIG)


### PR DESCRIPTION
psycopg2 had to be pinned to a lower version because of pinning in pgcli.

A new version of urllib3 was released lately which caused conflicts with requests & co.

Old redis pinning conflicted with new celery versions. I tried to pin redis to `>=3.2.0` and celery to `>=4.3.0`, but some tests broke with the never redis, so celery was pinned to `>=4.2.0,<4.3.0.`

Tests were failing also because of flake8 errors. These should now be fixed too.