### PR TITLE
Websauna  Typo in Timezone Variable Getter

### DIFF
--- a/websauna/system/core/vars.py
+++ b/websauna/system/core/vars.py
@@ -134,7 +134,7 @@ def site_time_zone(request, registry, settings):
 
     See `timezone abbreviation list <https://en.wikipedia.org/wiki/List_of_time_zone_abbreviations>`_.
     """
-    return settings.get("websauna.site_timezone", "UTC")
+    return settings.get("websauna.site_time_zone", "UTC")
 
 
 @var("js_in_head")


### PR DESCRIPTION
Though `websauna.site_time_zone` is referred in documentation and comment blocks as the setting for site time_zone, the variable itself looks for `websauna.site_timezone` in the config files. This results in UTC being returned even after setting a different time_zone. Culprit found!